### PR TITLE
Simplify constructing of JXMLTemplate

### DIFF
--- a/jx/build/JXMLTemplate.js
+++ b/jx/build/JXMLTemplate.js
@@ -1,9 +1,9 @@
-export default (function() {
+var str = (function() {
 	$CONSTRUCTOR
-
 	$NAME.prototype = Object.create($SUPERCLASS, $PROTOTYPE);
-
-	"export default $NAME;"
 }).toString()
-	.replace(/^function[^{]*{|}$/g, '')
-	.replace(/^ *"(.*)";?$/mg, '$1')
+  .replace(/^function[^{]*{|}$/g, '');
+
+str += 'export default $NAME;'
+
+export default str;


### PR DESCRIPTION
in Firefox, the old code will include `"use strict"` after `.toString()` function.
Hence, the exported value will be
```javascript
"
use strict
$CONSTRUCTOR
$NAME.prototype = Object.create($SUPERCLASS, $PROTOTYPE);
export default $NAME;
"
```

@yangbin @zz85 @jieyanhuang 