### PR TITLE
Fix incorrect label setting

### DIFF
--- a/jx/ui/Panel.jxml
+++ b/jx/ui/Panel.jxml
@@ -3,7 +3,7 @@
 		<![CDATA[
 			function onAttr(attr, delta) {
 				if ('title' in delta)
-					title.setAttr({ text: delta.label });
+					title.setAttr({ text: delta.title });
 			}
 		]]>
 	</script>


### PR DESCRIPTION
@yangbin @tgohn @zz85 
Stick to the convention of using `title` to setting the `Label` within `Panel`